### PR TITLE
docs: README and architecture refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ It implements the method described in:
 
 - **GUI capture and annotation** (`app.py`, PyQt6): load a video, scrub to the start/end of the sign, draw a region of interest around the signing space, flag one- vs two-handed signs, and trigger recognition.
 - **Video preprocessing** (`VideoTrimAndCropping.py`): trims/crops the clip with ffmpeg, probing for available hardware acceleration (VideoToolbox on macOS, CUDA, Intel Quick Sync, VA-API, DXVA2/D3D11VA on Windows) and falling back to multi-threaded CPU encoding.
-- **Face-relative normalization** (`faceDetection.py`, dlib frontal face detector): the face position and size give the origin and scale used to normalize hand coordinates, per section 4.1 of the paper.
+- **Face-relative normalization** (`faceDetection.py`, dlib frontal face detector): the face position and size give the origin and scale used to normalize hand coordinates, mirroring the paper's normalization step.
 - **Hand tracking** (`HandCoordinates.py`, MediaPipe Hands): per-frame dominant/non-dominant hand centroids, bounding boxes, and motion orientation vectors, with hands sorted left/right by horizontal position.
-- **Feature extraction** (`LinearInterpolation.py`, `hand_processing.py`): trajectories are resampled to a fixed 20-frame length (paper section 4.2), and start/end hand crops are skin-masked, grayscale-normalized, and resized for appearance comparison (paper section 6).
-- **DTW matching** (`sign_matcher.py`, `DTW.java`, `FastDTW.java`, `DTWServer.java`): the Java side does the actual Dynamic Time Warping; Python drives it over Py4J. A weighted combination of motion-feature distances plus hand-appearance distance produces a single similarity score per candidate (paper eq. 12), normalized to a 0-100% scale.
+- **Feature extraction** (`LinearInterpolation.py`, `hand_processing.py`): trajectories are resampled to a fixed 20-frame length, and start/end hand crops are skin-masked, grayscale-normalized, and resized for appearance comparison, following the same general approach as the paper.
+- **DTW matching** (`sign_matcher.py`, `DTW.java`, `FastDTW.java`, `DTWServer.java`): the Java side does the actual Dynamic Time Warping; Python drives it over Py4J. A weighted combination of motion-feature distances plus hand-appearance distance produces a single similarity score per candidate, normalized to a 0-100% scale.
 - **Database population** (`DatabasePopulator.py`, single-process; `DatabasePopulator-multi.py`, multi-process via `ProcessPoolExecutor`): batch-process a directory of reference videos into `sign_database/sign_data.json`.
 - **Raw capture decoding** (`New_Video_converter/`, C++): a standalone tool (`vid_extractor`) for decoding the lab's proprietary Bayer-encoded, zlib-compressed `.vid` capture format into individual frames, ahead of any of the Python processing above.
-- **Algorithm comparison scripts** (`benchmark.py`, `compareSigns.py`, `rank.py`, `DTWNormal.py`, `FastDTW.py`): compare standard DTW vs. FastDTW, and Python vs. Java-via-Py4J, on synthetic motion patterns (`signPatterns.py` generates circle/wave/zigzag trajectories — not real sign data). Useful for sanity-checking the algorithm implementations and relative speed, not for accuracy claims.
+- **Algorithm comparison scripts** (`benchmark.py`, `compareSigns.py`, `rank.py`, `DTWNormal.py`, `FastDTW.py`): compare standard DTW vs. FastDTW, and Python vs. Java-via-Py4J, on synthetic motion patterns (`signPatterns.py` generates circle/wave/zigzag trajectories, not real sign data). Useful for sanity-checking the algorithm implementations and relative speed, not for accuracy claims.
 
-No accuracy, latency, or dataset-size numbers are checked into the repo (`benchmark_results.json` is git-ignored), so none are claimed here — see Known limitations.
+No accuracy, latency, or dataset-size numbers are checked into the repo (`benchmark_results.json` is git-ignored), so none are claimed here; see Known limitations.
 
 ## Architecture
 
@@ -34,14 +34,14 @@ No accuracy, latency, or dataset-size numbers are checked into the repo (`benchm
 
 ```mermaid
 flowchart TD
-    A["Raw lab capture: .vid files\n(Bayer-encoded, zlib-compressed frames)"] --> B["New_Video_converter/vid_extractor (C++)\nVidHeader + bayer.cpp + vendored zlib 1.2.3"]
+    A["Raw lab capture: .vid files<br>(Bayer-encoded, zlib-compressed frames)"] --> B["New_Video_converter/vid_extractor (C++)<br>VidHeader + bayer.cpp + vendored zlib 1.2.3"]
     B --> C["Decompressed frames (PPM)"]
     D["Directory of sign videos (.mpg/.mp4)"] --> E["generate_video_list.py"]
-    E --> F["videos_to_add.txt\n(path, sign name, handedness)"]
+    E --> F["videos_to_add.txt<br>(path, sign name, handedness)"]
     C -.-> D
-    F --> G["DatabasePopulator.py\nor DatabasePopulator-multi.py (ProcessPoolExecutor)"]
-    G --> H["VideoTrimAndCropping.GetValues()\nper video, add_to_db=True"]
-    H --> I["sign_database/sign_data.json\n(features + metadata per sign)"]
+    F --> G["DatabasePopulator.py<br>or DatabasePopulator-multi.py (ProcessPoolExecutor)"]
+    G --> H["VideoTrimAndCropping.GetValues()<br>per video, add_to_db=True"]
+    H --> I["sign_database/sign_data.json<br>(features + metadata per sign)"]
 ```
 
 The C++ `vid_extractor` path and the Python `generate_video_list.py` path both terminate in ordinary video files that `DatabasePopulator` consumes; the `.vid` decoder is a preparatory step for archival lab recordings, not something the Python pipeline calls directly.
@@ -50,15 +50,15 @@ The C++ `vid_extractor` path and the Python `generate_video_list.py` path both t
 
 ```mermaid
 flowchart TD
-    A["app.py (PyQt6 GUI)\nload video, set start/end time, draw ROI"] --> B["VideoTrimAndCropping.GetValues()"]
-    B --> C["ffmpeg trim + crop\n(hardware-accel probe, CPU fallback)"]
-    C --> D["faceDetection.detect_face (dlib)\n-> origin, scaling_factor"]
-    D --> E["HandCoordinates (MediaPipe Hands)\n-> per-frame centroids, bboxes, orientation"]
-    E --> F["LinearInterpolation.InterpolateAndResample\n-> fixed 20-frame trajectories"]
-    F --> G["hand_processing: extract + preprocess\nstart/end hand crops"]
+    A["app.py (PyQt6 GUI)<br>load video, set start/end time, draw ROI"] --> B["VideoTrimAndCropping.GetValues()"]
+    B --> C["ffmpeg trim + crop<br>(hardware-accel probe, CPU fallback)"]
+    C --> D["faceDetection.detect_face (dlib)<br>-> origin, scaling_factor"]
+    D --> E["HandCoordinates (MediaPipe Hands)<br>-> per-frame centroids, bboxes, orientation"]
+    E --> F["LinearInterpolation.InterpolateAndResample<br>-> fixed 20-frame trajectories"]
+    F --> G["hand_processing: extract + preprocess<br>start/end hand crops"]
     G --> H["SignMatcher.find_matches_batch()"]
-    H --> I["Py4J -> DTWServer.java -> DTW.calculateDTW\nper candidate sign in sign_database"]
-    I --> J["Similarity scores normalized 0-100%,\ntop-k ranked"]
+    H --> I["Py4J -> DTWServer.java -> DTW.calculateDTW<br>per candidate sign in sign_database"]
+    I --> J["Similarity scores normalized 0-100%,<br>top-k ranked"]
     J --> K["app.py results page"]
 ```
 
@@ -92,9 +92,9 @@ sequenceDiagram
 - **Batched RPC over per-comparison RPC.** `find_matches_batch` sends the whole candidate set to Java in one `batchCalculateDTW` call, which parallelizes the distance computations across a Java `ExecutorService` server-side, instead of paying a Py4J round trip per candidate sign.
 - **Face-relative normalization, not raw pixel coordinates.** Hand centroids are recentered on the detected face position and scaled by face size (dlib), so the same sign performed at different distances from the camera produces comparable trajectories.
 - **Fixed-length resampling.** Variable-length hand trajectories are linearly interpolated to a fixed 20 frames (`LinearInterpolation.py`) before DTW, matching the paper's normalization step.
-- **Motion + appearance, weighted.** The match score combines DTW distance over several motion features (dominant/non-dominant centroids, inter-hand distance, orientation vectors) with a separate hand-appearance distance (skin-masked, normalized start/end hand crops), using fixed weights mirroring the paper's equation 12.
-- **Best-effort hardware acceleration.** ffmpeg trimming probes for VideoToolbox/CUDA/QSV/VAAPI/DXVA2 and falls back to multi-threaded CPU encoding; MediaPipe runs at `model_complexity=0` for CPU-friendliness. None of this is benchmarked in-repo — treat it as a portability affordance, not a performance claim.
-- **A separate C++ tool for the lab's raw format.** `New_Video_converter/` decodes a legacy Bayer + zlib `.vid` capture format used for some of the lab's archival recordings. It is vendored with a full copy of zlib 1.2.3 (including Windows/Delphi/Ada bindings unrelated to this project) rather than a slim dependency — see Known limitations.
+- **Motion + appearance, weighted.** The match score combines DTW distance over several motion features (dominant/non-dominant centroids, inter-hand distance, orientation vectors) with a separate hand-appearance distance (skin-masked, normalized start/end hand crops), using fixed weights mirroring the paper's weighted-combination approach.
+- **Best-effort hardware acceleration.** ffmpeg trimming probes for VideoToolbox/CUDA/QSV/VAAPI/DXVA2 and falls back to multi-threaded CPU encoding; MediaPipe runs at `model_complexity=0` for CPU-friendliness. None of this is benchmarked in-repo; treat it as a portability affordance, not a performance claim.
+- **A separate C++ tool for the lab's raw format.** `New_Video_converter/` decodes a legacy Bayer + zlib `.vid` capture format used for some of the lab's archival recordings. It is vendored with a full copy of zlib 1.2.3 (including Windows/Delphi/Ada bindings unrelated to this project) rather than a slim dependency (see Known limitations).
 
 ## Setup
 
@@ -110,7 +110,7 @@ source venv/bin/activate   # Windows: venv\Scripts\activate
 pip install PyQt6 opencv-python numpy ffmpeg-python py4j mediapipe scipy dlib
 ```
 
-`dlib` is required (used by `faceDetection.py`) but has no pinned version or `requirements.txt` in the repo; install whatever wheel is available for your platform. There are no secrets or environment variables to configure — all paths (video files, `sign_database/`) are passed as CLI arguments or picked via the GUI file dialog.
+`dlib` is required (used by `faceDetection.py`) but has no pinned version or `requirements.txt` in the repo; install whatever wheel is available for your platform. There are no secrets or environment variables to configure; all paths (video files, `sign_database/`) are passed as CLI arguments or picked via the GUI file dialog.
 
 Optional, platform-specific acceleration:
 - NVIDIA: CUDA + a CUDA-enabled OpenCV build.
@@ -136,12 +136,12 @@ javac DTW.java FastDTW.java DTWServer.java
 ### Building the reference database
 
 ```bash
-python generate_video_list.py /path/to/videos --one-handed
+python generate_video_list.py /path/to/videos
 # review/edit the generated videos_to_add.txt
 
 python DatabasePopulator-multi.py --workers 4 --batch_size 10 --video_list videos_to_add.txt
 ```
-(`DatabasePopulator.py` is the single-process version of the same tool and does not accept `--workers`/`--batch_size`; use `-multi` for parallel population.)
+`generate_video_list.py` writes handedness as `true` for every row (there is no `--one-handed` flag); edit `videos_to_add.txt` by hand to mark one-handed signs correctly before populating the database. (`DatabasePopulator.py` is the single-process version of the same tool and does not accept `--workers`/`--batch_size`; use `-multi` for parallel population.)
 
 ### Algorithm comparison scripts
 
@@ -150,7 +150,7 @@ python benchmark.py   # standard DTW vs FastDTW vs Java-via-Py4J, on synthetic p
 python rank.py         # rank benchmark_results.json by a chosen metric
 python compareSigns.py # standard DTW vs FastDTW timing/distance comparison
 ```
-These compare implementations against each other on synthetic geometric patterns (`signPatterns.py`), not against real sign-language data — treat their output as implementation sanity checks, not accuracy results.
+These compare implementations against each other on synthetic geometric patterns (`signPatterns.py`), not against real sign-language data; treat their output as implementation sanity checks, not accuracy results.
 
 ## Testing
 
@@ -161,13 +161,13 @@ These compare implementations against each other on synthetic geometric patterns
 - **No bundled dataset or trained/tuned parameters.** The feature weights (`f1`..`f6`, `f_hand` in `sign_matcher.py`) are fixed constants mirroring the paper, not fit or validated against a database in this repo.
 - **No accuracy or latency numbers in-repo.** `benchmark_results.json` is git-ignored and not committed; there is nothing here to cite for match accuracy or processing speed.
 - **`video_manager.py` appears to be an orphaned utility.** It manages its own `video_database.json` and isn't imported by `app.py`, `DatabasePopulator.py`, or `DatabasePopulator-multi.py`, which use `database_manager.SignDatabase` and `sign_database/sign_data.json` directly. Needs owner confirmation on whether it's still in use.
-- **Vendored zlib 1.2.3 source tree.** `New_Video_converter/zlib/` includes a full copy of zlib 1.2.3 (~17 MB, including Windows/Ada/Pascal/Delphi bindings and build artifacts unrelated to this project) committed directly rather than pulled in as a slim dependency. This is also why GitHub reports "SWIG" as the repo's primary language — it's an artifact of this vendored tree's file extensions, not anything SWIG-related in the actual project.
+- **Vendored zlib 1.2.3 source tree.** `New_Video_converter/zlib/` includes a full copy of zlib 1.2.3 (~17 MB, including Windows/Ada/Pascal/Delphi bindings and build artifacts unrelated to this project) committed directly rather than pulled in as a slim dependency. This is also why GitHub reports "SWIG" as the repo's primary language: it's an artifact of this vendored tree's file extensions, not anything SWIG-related in the actual project.
 - **No `requirements.txt` / dependency pinning**, and no `LICENSE` file.
 - **Manual, GUI-driven workflow.** There's no headless/batch "evaluate against a labeled test set" mode; recognition is invoked one clip at a time through the PyQt6 GUI (or by calling `GetValues` directly).
 
 ## Personal contribution
 
-Solo project. All 26 commits (Feb 2024 - Apr 2025) are authored by Prajit Viswanadha, including the video capture/ROI GUI, face-relative normalization, MediaPipe-based hand tracking and feature extraction, the Java DTW/FastDTW implementation and the Py4J integration layer, the batch database populators, and the algorithm-comparison scripts. `New_Video_converter/` wraps the research group's pre-existing raw-capture format and a vendored zlib; the surrounding build/integration work is original.
+Solo project. All 26 commits (Jan 2024 - Apr 2025) are authored by Prajit Viswanadha, including the video capture/ROI GUI, face-relative normalization, MediaPipe-based hand tracking and feature extraction, the Java DTW/FastDTW implementation and the Py4J integration layer, the batch database populators, and the algorithm-comparison scripts. `New_Video_converter/` wraps the research group's pre-existing raw-capture format and a vendored zlib; the surrounding build/integration work is original.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -1,201 +1,178 @@
 # SignDetection
 
-A dynamic sign language detection and recognition system built with Python, using the DTW (Dynamic Time Warping) algorithm to match sign language motions captured from videos.
+Video-based sign language lookup: given a short video clip of a sign, find the closest matches in a reference database using hand-motion trajectory comparison (Dynamic Time Warping).
 
-## Overview
+**Status: Research project.** Built solo, under the guidance of Professor Vassilis Athitsos in the UT Arlington CSE department, implementing the approach from the group's published paper. It is a working pipeline, not a packaged or deployed tool: there is no bundled dataset, no CI, and no measured accuracy numbers checked into the repo.
 
-SignDetection is a tool that enables the comparison and matching of sign language gestures from video inputs. The system tracks hand movements, normalizes the data, and uses Dynamic Time Warping (DTW) to find the closest matching sign from a database of known signs.
+## Problem statement
 
-This project is being developed under the guidance of **Professor Vassilis Athitsos** and implements the methods described in the paper:
+Looking up a sign in a large sign-language vocabulary from video is hard: the same sign varies in speed, framing, and hand shape between signers and even between repetitions by the same signer. Naive frame-by-frame comparison doesn't tolerate that variation. This project implements a query-by-example system: sign a gesture on camera, and the system normalizes the hand motion, aligns it against a database of known signs with Dynamic Time Warping, and returns a ranked list of candidate matches.
 
-> **A System for Large Vocabulary Sign Search**  
-> *Haijing Wang, Alexandra Stefan, Sajjad Moradi, Vassilis Athitsos, Carol Neidle, and Farhad Kamangar*  
-> *Computer Science and Engineering Department, University of Texas at Arlington*  
+It implements the method described in:
 
-The system builds upon prior research to enable the lookup of unknown sign language gestures using video input, leveraging DTW-based trajectory comparison combined with hand appearance analysis.
+> **A System for Large Vocabulary Sign Search**
+> Haijing Wang, Alexandra Stefan, Sajjad Moradi, Vassilis Athitsos, Carol Neidle, Farhad Kamangar
+> Computer Science and Engineering Department, University of Texas at Arlington
 
-### Key Features:
-- Video capture and processing with precise timing control
-- Face detection for motion normalization
-- Hand tracking using computer vision
-- DTW algorithm implementation for comparing sign patterns
-- PyQt6-based GUI for easy interaction
-- Database management for storing and retrieving sign data
-- GPU acceleration for faster processing
-- Parallel processing for database population
+## Core functionality
 
-## Requirements
+- **GUI capture and annotation** (`app.py`, PyQt6): load a video, scrub to the start/end of the sign, draw a region of interest around the signing space, flag one- vs two-handed signs, and trigger recognition.
+- **Video preprocessing** (`VideoTrimAndCropping.py`): trims/crops the clip with ffmpeg, probing for available hardware acceleration (VideoToolbox on macOS, CUDA, Intel Quick Sync, VA-API, DXVA2/D3D11VA on Windows) and falling back to multi-threaded CPU encoding.
+- **Face-relative normalization** (`faceDetection.py`, dlib frontal face detector): the face position and size give the origin and scale used to normalize hand coordinates, per section 4.1 of the paper.
+- **Hand tracking** (`HandCoordinates.py`, MediaPipe Hands): per-frame dominant/non-dominant hand centroids, bounding boxes, and motion orientation vectors, with hands sorted left/right by horizontal position.
+- **Feature extraction** (`LinearInterpolation.py`, `hand_processing.py`): trajectories are resampled to a fixed 20-frame length (paper section 4.2), and start/end hand crops are skin-masked, grayscale-normalized, and resized for appearance comparison (paper section 6).
+- **DTW matching** (`sign_matcher.py`, `DTW.java`, `FastDTW.java`, `DTWServer.java`): the Java side does the actual Dynamic Time Warping; Python drives it over Py4J. A weighted combination of motion-feature distances plus hand-appearance distance produces a single similarity score per candidate (paper eq. 12), normalized to a 0-100% scale.
+- **Database population** (`DatabasePopulator.py`, single-process; `DatabasePopulator-multi.py`, multi-process via `ProcessPoolExecutor`): batch-process a directory of reference videos into `sign_database/sign_data.json`.
+- **Raw capture decoding** (`New_Video_converter/`, C++): a standalone tool (`vid_extractor`) for decoding the lab's proprietary Bayer-encoded, zlib-compressed `.vid` capture format into individual frames, ahead of any of the Python processing above.
+- **Algorithm comparison scripts** (`benchmark.py`, `compareSigns.py`, `rank.py`, `DTWNormal.py`, `FastDTW.py`): compare standard DTW vs. FastDTW, and Python vs. Java-via-Py4J, on synthetic motion patterns (`signPatterns.py` generates circle/wave/zigzag trajectories — not real sign data). Useful for sanity-checking the algorithm implementations and relative speed, not for accuracy claims.
 
-- Python 3.9+
-- Required Python packages:
-  - PyQt6
-  - opencv-python
-  - numpy
-  - ffmpeg-python
-  - py4j
-  - mediapipe
-  - scipy
-  - psutil (for monitoring)
-  - matplotlib (for visualization)
+No accuracy, latency, or dataset-size numbers are checked into the repo (`benchmark_results.json` is git-ignored), so none are claimed here — see Known limitations.
 
-## Installation
+## Architecture
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/yourusername/SignDetection.git
-   cd SignDetection
-   ```
+### 1. Dataset preparation and database population
 
-2. Create and activate a virtual environment (recommended):
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows, use: venv\Scripts\activate
-   ```
+```mermaid
+flowchart TD
+    A["Raw lab capture: .vid files\n(Bayer-encoded, zlib-compressed frames)"] --> B["New_Video_converter/vid_extractor (C++)\nVidHeader + bayer.cpp + vendored zlib 1.2.3"]
+    B --> C["Decompressed frames (PPM)"]
+    D["Directory of sign videos (.mpg/.mp4)"] --> E["generate_video_list.py"]
+    E --> F["videos_to_add.txt\n(path, sign name, handedness)"]
+    C -.-> D
+    F --> G["DatabasePopulator.py\nor DatabasePopulator-multi.py (ProcessPoolExecutor)"]
+    G --> H["VideoTrimAndCropping.GetValues()\nper video, add_to_db=True"]
+    H --> I["sign_database/sign_data.json\n(features + metadata per sign)"]
+```
 
-3. Install the required dependencies:
-   ```bash
-   pip install PyQt6 opencv-python numpy ffmpeg-python py4j mediapipe scipy psutil matplotlib
-   ```
+The C++ `vid_extractor` path and the Python `generate_video_list.py` path both terminate in ordinary video files that `DatabasePopulator` consumes; the `.vid` decoder is a preparatory step for archival lab recordings, not something the Python pipeline calls directly.
 
-4. For GPU acceleration:
-   - For NVIDIA GPUs: Install CUDA and the CUDA-enabled version of OpenCV
-     ```bash
-     pip install opencv-python-contrib
-     ```
-   - For Apple Silicon (M1/M2): Install tensorflow-metal (optional, for additional acceleration)
-     ```bash
-     pip install tensorflow-metal
-     ```
+### 2. Recognition-time execution
 
-5. Compile and run the Java DTW implementation:
-   ```bash
-   javac DTW.java FastDTW.java DTWServer.java
-   java DTWServer
-   ```
+```mermaid
+flowchart TD
+    A["app.py (PyQt6 GUI)\nload video, set start/end time, draw ROI"] --> B["VideoTrimAndCropping.GetValues()"]
+    B --> C["ffmpeg trim + crop\n(hardware-accel probe, CPU fallback)"]
+    C --> D["faceDetection.detect_face (dlib)\n-> origin, scaling_factor"]
+    D --> E["HandCoordinates (MediaPipe Hands)\n-> per-frame centroids, bboxes, orientation"]
+    E --> F["LinearInterpolation.InterpolateAndResample\n-> fixed 20-frame trajectories"]
+    F --> G["hand_processing: extract + preprocess\nstart/end hand crops"]
+    G --> H["SignMatcher.find_matches_batch()"]
+    H --> I["Py4J -> DTWServer.java -> DTW.calculateDTW\nper candidate sign in sign_database"]
+    I --> J["Similarity scores normalized 0-100%,\ntop-k ranked"]
+    J --> K["app.py results page"]
+```
+
+### 3. Python-to-Java integration (Py4J)
+
+```mermaid
+sequenceDiagram
+    participant GUI as app.py (PyQt6)
+    participant VTC as VideoTrimAndCropping.py
+    participant SM as SignMatcher (Python, singleton)
+    participant GW as Py4J gateway (per thread)
+    participant DS as DTWServer.java (GatewayServer)
+    participant DTW as DTW.java / FastDTW.java
+
+    GUI->>VTC: GetValues(start, end, ROI, isOneHanded)
+    VTC->>SM: find_matches_batch(query_features, database_signs)
+    SM->>GW: convert numpy arrays -> Java double[][]
+    SM->>DS: batchCalculateDTW(query, list of candidate sequences)
+    DS->>DTW: submit DTW.calculateDTW per candidate to ExecutorService
+    DTW-->>DS: distance per candidate
+    DS-->>SM: double[] distances (Py4J return value)
+    SM-->>VTC: ranked (index, similarity) pairs
+    VTC-->>GUI: matches, origin, scaling_factor, features
+```
+
+`DTWServer.java` must be started first (`java DTWServer`) and stays up as a local JVM process; Py4J connects to it over a local socket rather than any network API. `SignMatcher` keeps one gateway per worker thread (`threading.local()`) so multiple batches can be in flight without serializing on a single connection, and prefers the batch RPC (`batchCalculateDTW`) over one call per candidate to cut down on Py4J round-trip overhead.
+
+## Key technical decisions
+
+- **DTW in Java, orchestration in Python.** The DTW/FastDTW core is implemented in Java (`DTW.java`, `FastDTW.java`) and exposed to Python via a persistent Py4J `GatewayServer` (`DTWServer.java`), rather than reimplementing DTW natively in Python or wrapping a C extension. `benchmark.py`/`compareSigns.py` exist specifically to compare the Python and Java implementations against each other.
+- **Batched RPC over per-comparison RPC.** `find_matches_batch` sends the whole candidate set to Java in one `batchCalculateDTW` call, which parallelizes the distance computations across a Java `ExecutorService` server-side, instead of paying a Py4J round trip per candidate sign.
+- **Face-relative normalization, not raw pixel coordinates.** Hand centroids are recentered on the detected face position and scaled by face size (dlib), so the same sign performed at different distances from the camera produces comparable trajectories.
+- **Fixed-length resampling.** Variable-length hand trajectories are linearly interpolated to a fixed 20 frames (`LinearInterpolation.py`) before DTW, matching the paper's normalization step.
+- **Motion + appearance, weighted.** The match score combines DTW distance over several motion features (dominant/non-dominant centroids, inter-hand distance, orientation vectors) with a separate hand-appearance distance (skin-masked, normalized start/end hand crops), using fixed weights mirroring the paper's equation 12.
+- **Best-effort hardware acceleration.** ffmpeg trimming probes for VideoToolbox/CUDA/QSV/VAAPI/DXVA2 and falls back to multi-threaded CPU encoding; MediaPipe runs at `model_complexity=0` for CPU-friendliness. None of this is benchmarked in-repo — treat it as a portability affordance, not a performance claim.
+- **A separate C++ tool for the lab's raw format.** `New_Video_converter/` decodes a legacy Bayer + zlib `.vid` capture format used for some of the lab's archival recordings. It is vendored with a full copy of zlib 1.2.3 (including Windows/Delphi/Ada bindings unrelated to this project) rather than a slim dependency — see Known limitations.
+
+## Setup
+
+Requires Python 3.9+, a JDK (for the DTW server), and ffmpeg on `PATH`.
+
+```bash
+git clone https://github.com/V-prajit/SignDetection.git
+cd SignDetection
+
+python -m venv venv
+source venv/bin/activate   # Windows: venv\Scripts\activate
+
+pip install PyQt6 opencv-python numpy ffmpeg-python py4j mediapipe scipy dlib
+```
+
+`dlib` is required (used by `faceDetection.py`) but has no pinned version or `requirements.txt` in the repo; install whatever wheel is available for your platform. There are no secrets or environment variables to configure — all paths (video files, `sign_database/`) are passed as CLI arguments or picked via the GUI file dialog.
+
+Optional, platform-specific acceleration:
+- NVIDIA: CUDA + a CUDA-enabled OpenCV build.
+- Apple Silicon: `tensorflow-metal` (optional; MediaPipe/ffmpeg acceleration works without it via VideoToolbox).
+
+Compile the Java side:
+```bash
+javac DTW.java FastDTW.java DTWServer.java
+```
 
 ## Usage
 
-### Running the Application
-
-1. Start the DTW server:
+1. Start the DTW server (leave it running):
    ```bash
    java DTWServer
    ```
-
-2. Launch the application:
+2. Launch the GUI:
    ```bash
    python app.py
    ```
+3. In the GUI: load a video, set the start/end time of the sign, draw a region of interest around the signing space, check "One-Handed Video" if applicable, then "Process Video" to see ranked matches.
 
-### Using the GUI
+### Building the reference database
 
-1. **Load Video**: Click "Load Video" to select a sign language video file.
-2. **Set Time Range**: Use "Set Start Time" and "Set End Time" to define the segment containing the sign.
-3. **Select Region**: Draw a rectangle around the signing area by clicking and dragging.
-4. **One-Handed Option**: Check the "One-Handed Video" box if the sign only uses one hand.
-5. **Process Video**: Click "Process Video" to analyze the sign.
-6. **View Results**: The system will display matching signs from the database with similarity scores.
-
-### Adding New Signs to the Database
-
-To add a new sign:
-1. Prepare a clear video of the sign.
-2. Generate a list of videos to process:
-   ```bash
-   python generate_video_list.py /path/to/videos --one-handed
-   ```
-   - Use `--one-handed` flag if videos are mostly one-handed signs
-   - Review and edit the generated `videos_to_add.txt` file as needed
-
-3. Run the enhanced database populator with GPU acceleration:
-   ```bash
-   python DatabasePopulator.py --workers 4 --batch_size 10 --video_list videos_to_add.txt
-   ```
-   - Adjust the `--workers` parameter to match your system (usually CPU core count minus 1)
-   - The `--batch_size` parameter controls how many videos to process before saving
-
-4. Monitor resource usage during processing (optional):
-   ```bash
-   python resource_monitor.py --output resource_log.csv
-   ```
-
-## Performance Optimization
-
-### Hardware-Specific Optimizations
-
-#### NVIDIA GPUs (e.g., GTX 1660)
-- The system automatically detects and uses CUDA acceleration for video processing
-- MediaPipe hand tracking utilizes GPU acceleration
-- FFmpeg operations are hardware-accelerated using CUDA
-- For best performance, use 3-4 worker processes (adjust based on your RAM)
-
-#### Apple Silicon (M1/M2 Macs)
-- Video processing uses VideoToolbox hardware acceleration
-- MediaPipe hand tracking benefits from Metal GPU acceleration
-- Optimized memory usage for Apple's unified memory architecture
-- Best performance with 4-6 worker processes on M1 Pro/Max
-
-#### CPU-Only Systems
-- The system falls back to multi-threaded CPU processing
-- FFmpeg operations use multiple CPU threads
-- Recommended to use (CPU core count - 1) worker processes
-
-### Resource Monitoring
-
-The included `resource_monitor.py` script provides real-time monitoring of:
-- CPU usage
-- Memory consumption
-- GPU utilization (on supported platforms)
-- Process count
-
-It generates CSV logs and visual graphs to help optimize worker count for your specific hardware.
-
-## How It Works
-
-1. **Video Processing**: The system extracts the specified segment of the video and crops it to the region of interest, using hardware acceleration when available.
-2. **Face Detection**: Detects the face to establish a reference point for normalization.
-3. **Hand Tracking**: Tracks hand positions throughout the video using MediaPipe with GPU acceleration.
-4. **Feature Extraction**: Extracts features like hand centroids, orientations, and hand shape descriptors.
-5. **DTW Matching**: Uses Dynamic Time Warping to compare the extracted features with signs in the database.
-6. **Ranking**: Ranks potential matches based on similarity scores.
-
-## Project Structure
-
-- **app.py**: Main GUI application (lightweight, runs on Raspberry Pi).
-- **sign_matcher.py**: Implements sign comparison logic using DTW.
-- **database_manager.py**: Handles sign database operations.
-- **VideoTrimAndCropping.py**: Video processing functions with hardware acceleration.
-- **HandCoordinates.py**: GPU-accelerated hand tracking and feature extraction.
-- **faceDetection.py**: Face detection for normalization.
-- **DTW.java/FastDTW.java**: Java implementation of the DTW algorithm.
-- **DTWServer.java**: Java server for DTW calculations.
-- **DatabasePopulator.py**: Multi-process database population with GPU acceleration.
-- **resource_monitor.py**: System resource monitoring and visualization.
-- **sign_database/**: Directory containing sign data.
-
-## Benchmarking
-
-Run the benchmark script to evaluate system performance:
 ```bash
-python benchmark.py
+python generate_video_list.py /path/to/videos --one-handed
+# review/edit the generated videos_to_add.txt
+
+python DatabasePopulator-multi.py --workers 4 --batch_size 10 --video_list videos_to_add.txt
 ```
-The results will be saved in `benchmark_results.json` and can be used to tune parameters.
+(`DatabasePopulator.py` is the single-process version of the same tool and does not accept `--workers`/`--batch_size`; use `-multi` for parallel population.)
 
-## Troubleshooting
+### Algorithm comparison scripts
 
-### GPU Not Being Used
-- Verify proper GPU drivers are installed
-- Check that OpenCV has GPU/CUDA support
-- Run the resource monitor to confirm GPU activity
-- Increase batch size to ensure GPU is fully utilized
+```bash
+python benchmark.py   # standard DTW vs FastDTW vs Java-via-Py4J, on synthetic patterns
+python rank.py         # rank benchmark_results.json by a chosen metric
+python compareSigns.py # standard DTW vs FastDTW timing/distance comparison
+```
+These compare implementations against each other on synthetic geometric patterns (`signPatterns.py`), not against real sign-language data — treat their output as implementation sanity checks, not accuracy results.
 
-### Process Crashes with Out-of-Memory Errors
-- Reduce the number of worker processes
-- Decrease batch size
-- Ensure you have sufficient system RAM (16GB+ recommended)
+## Testing
 
-### Slow Processing Despite GPU
-- Check hardware acceleration with `ffmpeg -hwaccels`
-- Ensure MediaPipe is utilizing the GPU
-- Verify the Java DTW server is running
-- Use resource monitor to identify bottlenecks
+`test_sign_matching.py` is an ad hoc smoke script (random feature vectors through `SignDatabase` and `SignMatcher`, printed output, no assertions) run directly with `python test_sign_matching.py`. There is no test framework, no CI, and no coverage measurement in the repo.
+
+## Known limitations
+
+- **No bundled dataset or trained/tuned parameters.** The feature weights (`f1`..`f6`, `f_hand` in `sign_matcher.py`) are fixed constants mirroring the paper, not fit or validated against a database in this repo.
+- **No accuracy or latency numbers in-repo.** `benchmark_results.json` is git-ignored and not committed; there is nothing here to cite for match accuracy or processing speed.
+- **`video_manager.py` appears to be an orphaned utility.** It manages its own `video_database.json` and isn't imported by `app.py`, `DatabasePopulator.py`, or `DatabasePopulator-multi.py`, which use `database_manager.SignDatabase` and `sign_database/sign_data.json` directly. Needs owner confirmation on whether it's still in use.
+- **Vendored zlib 1.2.3 source tree.** `New_Video_converter/zlib/` includes a full copy of zlib 1.2.3 (~17 MB, including Windows/Ada/Pascal/Delphi bindings and build artifacts unrelated to this project) committed directly rather than pulled in as a slim dependency. This is also why GitHub reports "SWIG" as the repo's primary language — it's an artifact of this vendored tree's file extensions, not anything SWIG-related in the actual project.
+- **No `requirements.txt` / dependency pinning**, and no `LICENSE` file.
+- **Manual, GUI-driven workflow.** There's no headless/batch "evaluate against a labeled test set" mode; recognition is invoked one clip at a time through the PyQt6 GUI (or by calling `GetValues` directly).
+
+## Personal contribution
+
+Solo project. All 26 commits (Feb 2024 - Apr 2025) are authored by Prajit Viswanadha, including the video capture/ROI GUI, face-relative normalization, MediaPipe-based hand tracking and feature extraction, the Java DTW/FastDTW implementation and the Py4J integration layer, the batch database populators, and the algorithm-comparison scripts. `New_Video_converter/` wraps the research group's pre-existing raw-capture format and a vendored zlib; the surrounding build/integration work is original.
+
+## Attribution
+
+Developed under the guidance of Professor Vassilis Athitsos, UT Arlington CSE, implementing the method from Wang, Stefan, Moradi, Athitsos, Neidle, and Kamangar, "A System for Large Vocabulary Sign Search."
+
+## License
+
+No `LICENSE` file is present in this repository. Until one is added, all rights are reserved by default; add a license (for example MIT or Apache-2.0) if you intend this to be reused.


### PR DESCRIPTION
## Summary
- Rewrites the README to a Tier 1 standard: problem statement, core functionality, three Mermaid architecture/execution diagrams, key technical decisions, setup, usage, testing, known limitations, personal contribution, and license status.
- Traces every claim back to the source in this repo (dlib for face detection, MediaPipe for hand tracking, Py4J-bridged Java DTW/FastDTW, ffmpeg trim with hardware-acceleration probing, `ProcessPoolExecutor`-based multi-process database population).
- Fixes several stale/inaccurate claims in the previous README (see "Docs changed" below).
- Applied a round of reviewer feedback (style, a broken usage example, unverifiable paper cross-references, a commit-date error, and Mermaid line-break reliability); see "Validation performed" and "Metrics softened or removed" for what changed.

## Why it matters
The previous README described a `resource_monitor.py` script and CLI flags that don't exist on the file it named, and omitted a hard runtime dependency (`dlib`). Anyone following it top to bottom would hit an import error and a missing-file error. The rewrite is grounded in what's actually in the repo and calls out what isn't (no dataset, no accuracy numbers, no CI, no license).

## Docs changed
- `README.md` — full rewrite, plus a follow-up fix commit.
  - Fixed: `python DatabasePopulator.py --workers 4 --batch_size 10 ...` doesn't work — `DatabasePopulator.py` has no `--workers`/`--batch_size` flags; only `DatabasePopulator-multi.py` does. Usage section now points at the right script.
  - Fixed: dropped `resource_monitor.py` instructions/section — that file is not in the repository (checked `git log` and working tree; no trace of it ever being committed).
  - Fixed: dropped `psutil`/`matplotlib` from the dependency list — both were only used by the missing `resource_monitor.py`; neither is imported anywhere else in the repo.
  - Added: `dlib` to the dependency list — it's imported directly in `faceDetection.py` and was missing from the old Requirements section.
  - Added: explanation for why GitHub reports "SWIG" as the primary language (vendored zlib-1.2.3 tree under `New_Video_converter/zlib/`, not anything SWIG-related in the actual project).
  - Added: note that `video_manager.py` appears orphaned (own JSON store, not imported by `app.py` or either `DatabasePopulator*` script) — flagged for owner confirmation rather than removed, since this PR is docs-only.
  - Fixed (review pass): the `generate_video_list.py --one-handed` example in "Building the reference database" doesn't work — the script's argparse only defines `root_dir` and `--output`/`-o`; there is no `--one-handed` flag, and the script hardcodes `handedness = "true"` for every row. The example now shows the real invocation and documents that `videos_to_add.txt` must be hand-edited for one-handed signs.
  - Fixed (review pass): removed all 7 em dash characters (style rule), replaced with hyphens, commas, semicolons, or parentheses depending on context.
  - Fixed (review pass): "Feb 2024 - Apr 2025" commit range corrected to "Jan 2024 - Apr 2025" — `git log --reverse` on `main` shows the first commit dated 2024-01-29, not February.
  - Fixed (review pass): Mermaid diagram node labels switched from literal `\n` to `<br>` for more reliable line breaks across Mermaid renderer versions.

## Diagrams added
1. Dataset preparation / compression pipeline — raw `.vid` decoding (`New_Video_converter/vid_extractor`) and the `generate_video_list.py` -> `DatabasePopulator[-multi].py` -> `sign_database/sign_data.json` path.
2. Recognition-time execution — GUI trigger through ffmpeg trim, dlib face detection, MediaPipe hand tracking, resampling/feature extraction, DTW matching, to ranked results.
3. Python-to-Java integration sequence diagram — how `SignMatcher` (Python, Py4J client, thread-local gateways) talks to `DTWServer.java` (persistent local `GatewayServer`) for batched DTW distance calculation.

All three are derived from reading `app.py`, `VideoTrimAndCropping.py`, `faceDetection.py`, `HandCoordinates.py`, `sign_matcher.py`, `DTW.java`, `DTWServer.java`, `DatabasePopulator.py`/`DatabasePopulator-multi.py`, and `New_Video_converter/` (Makefile, main.cpp, VidHeader.h).

## Metadata changed
- `gh repo edit` description: `null` -> see repo edit in this PR's associated commit/session (empty -> descriptive one-liner).
- `gh repo edit` topics: `[]` -> `sign-language, computer-vision, dynamic-time-warping, mediapipe, py4j, research`
- No `--homepage` set (none existed, none verified/added).

## Metrics used
None. No accuracy, latency, dataset-size, or benchmark numbers are cited anywhere in the new README.

## Metrics softened or removed
- Removed implied guarantees around GPU acceleration ("automatically detects and uses CUDA... for best performance use N workers") and reframed as "best-effort, unbenchmarked in this repo."
- Removed/reframed `benchmark.py`/`compareSigns.py` as synthetic-pattern implementation sanity checks (they run against `signPatterns.py`-generated circle/wave/zigzag data), not accuracy results — the old README didn't make this distinction.
- Review pass: removed exact paper cross-references that have no supporting evidence in the repo ("per section 4.1", "paper section 4.2", "paper section 6", "paper eq. 12" — `grep` for these terms/section numbers outside the README returns nothing). Replaced with general framing ("mirroring the paper's normalization step", "following the same general approach as the paper", "mirroring the paper's weighted-combination approach") that doesn't assert unverifiable section/equation-level detail.

## Validation performed
- Read every Python and Java source file in the repo, `New_Video_converter/Makefile` and `main.cpp`/`VidHeader.h`, `.gitignore`, `.gitattributes`.
- Cross-checked README claims against actual imports (`grep` over all `.py` files) and actual CLI arguments (`argparse` calls in both `DatabasePopulator*.py`).
- Confirmed via `git log` (26 commits, Jan 2024 - Apr 2025, all one author) that this is a solo project with no hackathon signal, and confirmed the last commit is what introduced `New_Video_converter/` (including vendored zlib).
- Confirmed via `gh api repos/V-prajit/SignDetection/languages` that "SWIG" is the top language, and traced it to the vendored zlib tree (only `.i` file in the repo is inside `New_Video_converter/zlib/zlib-1.2.3/contrib/vstudio/vc8/testzlib.i`; the byte-weighted language mix otherwise matches the zlib tree's C/Assembly/C++/Ada/Pascal/C#/DCL/HTML/XSLT content).
- No demo/deployment links exist in the repo to verify.
- Review pass: `grep -n` for the em dash character (U+2014) across `README.md` — confirmed 0 remain after the fix.
- Review pass: read `generate_video_list.py`'s `argparse` block directly — confirmed only `root_dir` (positional) and `--output`/`-o` are defined, no `--one-handed`; confirmed `is_one_handed = "true"` is hardcoded in the file-walk loop.
- Review pass: `grep -rniE "athitsos|vassilis|neidle|kamangar|moradi|large vocabulary|wang"` across all `.py`/`.java`/`.md`/`.txt` files excluding `README.md` — zero hits, confirming the advisor name and full paper citation have no in-repo corroboration; kept the high-level framing (solo project implementing a published paper's approach, under an advisor) but flagged the specific names/citation below for owner confirmation, and dropped the specific section/equation numbers per "Metrics softened or removed" above.
- Review pass: `git log main --reverse --format='%ad' --date=short | head -1` -> `2024-01-29`; `git log main --format='%ad' --date=short | head -1` -> `2025-04-16`. Confirmed the commit-date range fix.
- Pushed follow-up commit `af12fbc` to `docs/architecture-readme-refresh-2026` and verified `git diff` output matches intended changes before pushing.

## Known uncertainties
- Whether `video_manager.py` is still in active use or is dead code from an earlier iteration — flagged in README, not removed.
- Whether the dependency list is complete/pinned for every platform (no `requirements.txt` exists to cross-check against).

## Needs owner confirmation
- Confirm "Research project" status framing is still accurate (vs. e.g. coursework or a status the owner wants labeled differently).
- Confirm whether `New_Video_converter/zlib/` (full zlib-1.2.3 source tree, ~17 MB) should be trimmed to just the needed `.c`/`.h` files or fetched at build time instead of vendored wholesale — left as-is since this PR is docs/metadata only.
- Confirm whether `video_manager.py` should be removed, wired in, or documented differently.
- Confirm license intent (MIT/Apache-2.0/other) — no `LICENSE` file exists; recommend adding one.
- **New:** confirm the advisor attribution ("under the guidance of Professor Vassilis Athitsos") and the exact paper citation/author list ("A System for Large Vocabulary Sign Search" by Wang, Stefan, Moradi, Athitsos, Neidle, Kamangar) are accurate. Nothing in the repo's code, comments, or commit history corroborates these names or the citation (checked via `grep` across all source files) — they're carried over from the previous README draft on the owner's word. If confirmed, no further change needed; if not, the Attribution section and the "Problem statement" citation block should be edited or removed.

## Missing media
No screenshots, GIFs, or demo videos exist in the repository or were referenced in the old README. None were fabricated. Flagged as a manual followup if the owner wants the GUI's ROI-drawing/results screens documented visually.

## Security notes
No secrets, tokens, internal URLs, or employer-specific information are referenced anywhere in this repo or this PR. Nothing was added or removed on that front.
